### PR TITLE
feat: adjustable tentacle control points

### DIFF
--- a/src/gui/gui.ts
+++ b/src/gui/gui.ts
@@ -30,6 +30,8 @@ const DEFAULT_LAYOUT_PROPERTIES = {
   columnSpacing: 90,
   tentacleWidth: 2,
   tentacleSpacing: 5,
+  inOutCPDistance: 0.3,
+  bundleCPDistance: 0.6,
   sampleFontSize: 12,
   showLegend: true,
   phylogenyColorScheme: true,
@@ -86,6 +88,8 @@ export function setupGui(container: HTMLElement, tables: DataTables) {
   layoutFolder.add(layoutProps, "columnSpacing", 10, 200);
   layoutFolder.add(layoutProps, "tentacleWidth", 0.1, 5);
   layoutFolder.add(layoutProps, "tentacleSpacing", 0, 10);
+  layoutFolder.add(layoutProps, "inOutCPDistance", 0.1, 0.45);
+  layoutFolder.add(layoutProps, "bundleCPDistance", 0.1, 1.2);
   layoutFolder.add(layoutProps, "bellTipShape", 0, 1);
   layoutFolder.add(layoutProps, "bellTipSpread", 0, 1);
   layoutFolder.add(layoutProps, "bellStrokeWidth", 0, 3);

--- a/src/jellyfish.ts
+++ b/src/jellyfish.ts
@@ -708,7 +708,7 @@ function drawTentacles(
         const iMid = inputCoords.y + inputCoords.height / 2;
 
         // The distance as a fraction of column spacing
-        const inputOutputCPDist = 0.3;
+        const inputOutputCPDist = layoutProps.inOutCPDistance;
         // Position of bezier's control points (input and output)
         const ixc = lerp(ox, ix, 1 - inputOutputCPDist);
         const oxc = lerp(ox, ix, inputOutputCPDist);
@@ -726,7 +726,8 @@ function drawTentacles(
         // points.
         const q = 2;
         const scDist =
-          0.9 / ((slopeMultiplier([ix - ox, iy - oy]) + q) / (1 + q));
+          layoutProps.bundleCPDistance /
+          ((slopeMultiplier([ixc - oxc, iy - oy]) + q) / (1 + q));
 
         const midXCpOffset = lerp(ix, sx, 1 - scDist * 0.5) - sx;
         const midYCpOffset = lerp(iMid, sy, 1 - scDist) - sy;

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -19,6 +19,8 @@ export interface LayoutProperties extends BellPlotProperties {
   columnSpacing: number;
   tentacleWidth: number;
   tentacleSpacing: number;
+  inOutCPDistance: number;
+  bundleCPDistance: number;
   sampleFontSize: number;
   showLegend: boolean;
   phylogenyColorScheme: boolean;


### PR DESCRIPTION
This PR introduces two new layout parameters that allow for adjusting the bezier curve control points of tentacles and tentacle bundles.

`inOutCPDistance` controls the distance of control points from the sample rectangles.
`bundleCPDistance` controls the length of the tentacle bundle, i.e., for how long the individual tentacles stay within the bundle.

The default for `bundleCPDistance` was changed (from 0.9 to 0.6) a bit to reduce the kinkiness of some tentacles.

https://github.com/user-attachments/assets/78444774-5c02-4794-ae03-736d7d92eb0e

